### PR TITLE
Fix #261: RE 2, random BGM requires RE1 installation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 * **Rusty** - Ark, Kevin, Richard, William, Wesker (RE 5), and extra models
 * **StarringRole** - Rebecca model
 * **re_duke** - RDT information
+* **HazNut** - a bugfix
 * **Classic RE Modding community discord**
 
 Special thanks to all **BioRand** streamers and bug reporters!

--- a/IntelOrca.Biohazard/BaseRandomiser.cs
+++ b/IntelOrca.Biohazard/BaseRandomiser.cs
@@ -489,9 +489,14 @@ namespace IntelOrca.Biohazard
             return new[] { "chris", "jill", "barry", "rebecca", "wesker", "enrico", "richard" };
         }
 
-        protected bool MusicAlbumSelected(string album)
+        protected bool MusicAlbumSelected(RandoConfig config, string album)
         {
-            return GetMusicAlbums().Contains(album, StringComparer.OrdinalIgnoreCase);
+            var albumIndex = Array.FindIndex(GetMusicAlbums(), x => x.Equals(album, StringComparison.OrdinalIgnoreCase));
+            if (albumIndex > -1 && albumIndex < config.EnabledBGMs.Length)
+            {
+                return config.EnabledBGMs[albumIndex];
+            }
+            return false;
         }
 
         public virtual string[] GetMusicAlbums()

--- a/IntelOrca.Biohazard/RE1/Re1Randomiser.cs
+++ b/IntelOrca.Biohazard/RE1/Re1Randomiser.cs
@@ -93,7 +93,7 @@ namespace IntelOrca.Biohazard.RE1
 
         public override void Generate(RandoConfig config, ReInstallConfig reConfig, IRandoProgress progress, string installPath, string modPath)
         {
-            if (config.RandomBgm && MusicAlbumSelected("RE2"))
+            if (config.RandomBgm && MusicAlbumSelected(config, "RE2"))
             {
                 if (!reConfig.IsEnabled(BioVersion.Biohazard2))
                 {

--- a/IntelOrca.Biohazard/RE2/Re2Randomiser.cs
+++ b/IntelOrca.Biohazard/RE2/Re2Randomiser.cs
@@ -86,7 +86,7 @@ namespace IntelOrca.Biohazard.RE2
         {
             _reInstallConfig = reConfig;
 
-            if (config.RandomBgm && MusicAlbumSelected("RE1"))
+            if (config.RandomBgm && MusicAlbumSelected(config, "RE1"))
             {
                 if (!reConfig.IsEnabled(BioVersion.Biohazard1))
                 {


### PR DESCRIPTION
Fixes #261