### PR TITLE
(UI feature) Pie chart distribution tooltips

### DIFF
--- a/biorand/MainWindow.xaml.cs
+++ b/biorand/MainWindow.xaml.cs
@@ -384,12 +384,15 @@ namespace IntelOrca.Biohazard.BioRand
                 Value = keyItems,
                 Color = Colors.LightBlue
             });
-            pieItemRatios.Records.Add(new PieChart.Record()
+            if (SelectedGame == 2)
             {
-                Name = "Gunp...",
-                Value = gunpowder,
-                Color = Colors.Gray
-            });
+                pieItemRatios.Records.Add(new PieChart.Record()
+                {
+                    Name = "Gunp...",
+                    Value = gunpowder,
+                    Color = Colors.Gray
+                });
+            }
             pieItemRatios.Records.Add(new PieChart.Record()
             {
                 Name = "Ammo",

--- a/biorand/MainWindow.xaml.cs
+++ b/biorand/MainWindow.xaml.cs
@@ -384,15 +384,12 @@ namespace IntelOrca.Biohazard.BioRand
                 Value = keyItems,
                 Color = Colors.LightBlue
             });
-            if (SelectedGame == 2)
+            pieItemRatios.Records.Add(new PieChart.Record()
             {
-                pieItemRatios.Records.Add(new PieChart.Record()
-                {
-                    Name = "Gunp...",
-                    Value = gunpowder,
-                    Color = Colors.Gray
-                });
-            }
+                Name = "Gunp...",
+                Value = gunpowder,
+                Color = Colors.Gray
+            });
             pieItemRatios.Records.Add(new PieChart.Record()
             {
                 Name = "Ammo",

--- a/biorand/PieChart.xaml.cs
+++ b/biorand/PieChart.xaml.cs
@@ -262,7 +262,7 @@ namespace IntelOrca.Biohazard.BioRand
         {
             if (record.Name == String.Empty)
                 return null; // Ignore padding records.
-			double p = record.Value / total * 100;
+            double p = record.Value / total * 100;
             return $"{record.Name}: {Math.Round(p, 2)}%";
         }
 

--- a/biorand/PieChart.xaml.cs
+++ b/biorand/PieChart.xaml.cs
@@ -258,9 +258,11 @@ namespace IntelOrca.Biohazard.BioRand
             return ((color.R / 255.0) * 0.2126) + ((color.G / 255.0) * 0.7152) + ((color.B / 255.0) * 0.0722);
         }
 
-        private static string GetRecordToolTip(Record record, double total)
+        private static object GetRecordToolTip(Record record, double total)
         {
-            double p = record.Value / total * 100;
+            if (record.Name == String.Empty)
+                return null; // Ignore padding records.
+			double p = record.Value / total * 100;
             return $"{record.Name}: {Math.Round(p, 2)}%";
         }
 

--- a/biorand/PieChart.xaml.cs
+++ b/biorand/PieChart.xaml.cs
@@ -47,6 +47,7 @@ namespace IntelOrca.Biohazard.BioRand
                 circle.Fill = new SolidColorBrush(record.Color);
                 circle.Width = radius * 2;
                 circle.Height = radius * 2;
+                circle.ToolTip = GetRecordToolTip(record, total);
                 gridItems.Add(circle);
                 gridItems.Add(CreatePieLabel(record, new Point()));
             }
@@ -86,6 +87,7 @@ namespace IntelOrca.Biohazard.BioRand
                     var path = new Path();
                     path.Fill = new SolidColorBrush(record.Color);
                     path.Data = pathGeometry;
+                    path.ToolTip = GetRecordToolTip(record, total);
                     gridItems.Add(path);
                     gridItems.Add(CreatePieLabel(record, new Point(textPosition.X - radius, textPosition.Y - radius)));
 
@@ -129,6 +131,7 @@ namespace IntelOrca.Biohazard.BioRand
         {
             var grid = new Grid();
             var index = 0;
+            var total = records.Sum(x => x.Value);
             foreach (var record in records)
             {
                 if (record.Value == 0)
@@ -149,7 +152,7 @@ namespace IntelOrca.Biohazard.BioRand
                     new SolidColorBrush(Colors.White);
                 textBlock.Text = record.Name;
                 textBlock.TextAlignment = TextAlignment.Center;
-                textBlock.ToolTip = record.Name;
+                textBlock.ToolTip = GetRecordToolTip(record, total);
                 textBlock.Padding = new Thickness(2, 0, 2, 0);
                 textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
 
@@ -246,12 +249,19 @@ namespace IntelOrca.Biohazard.BioRand
             textBlock.TextAlignment = TextAlignment.Center;
             textBlock.Height = 12;
             textBlock.FontSize = 8;
+            textBlock.IsHitTestVisible = false;
             return textBlock;
         }
 
         private static double GetLuma(Color color)
         {
             return ((color.R / 255.0) * 0.2126) + ((color.G / 255.0) * 0.7152) + ((color.B / 255.0) * 0.0722);
+        }
+
+        private static string GetRecordToolTip(Record record, double total)
+        {
+            double p = record.Value / total * 100;
+            return $"{record.Name}: {Math.Round(p, 2)}%";
         }
 
         [DebuggerDisplay("({Name}, {Value})")]

--- a/biorand/PieChart.xaml.cs
+++ b/biorand/PieChart.xaml.cs
@@ -131,7 +131,7 @@ namespace IntelOrca.Biohazard.BioRand
         {
             var grid = new Grid();
             var index = 0;
-            var total = records.Sum(x => x.Value);
+            var total = Records.Sum(x => x.Value);
             foreach (var record in records)
             {
                 if (record.Value == 0)


### PR DESCRIPTION
I'm a sucker for trying to find well-rounded ratios with the distribution sliders. The pie charts are a nice visual aid, but it can be tricky to nail down the exact values you want.

This PR adds tooltips to pie chart records, displaying their weight as percentages (rounded to 2 decimals):

![2023-11-04_15-21-57](https://github.com/IntelOrca/biorand/assets/345016/77d2ebc7-ce0f-467b-b6c7-066193ab6028)

![devenv_2023-11-04_15-22-24](https://github.com/IntelOrca/biorand/assets/345016/f26eb12a-ce47-4600-bc39-0750ae553428)
